### PR TITLE
Fix workflow action search after Falcon console UI change

### DIFF
--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -45,14 +45,14 @@ test.describe('IdP Notifications - E2E Tests', () => {
     for (const actionName of expectedActions) {
       // Search for the specific action
       await expect(searchBox).toBeEnabled({ timeout: 10000 });
-      await searchBox.fill(actionName);
+      await searchBox.clear();
+      await searchBox.pressSequentially(actionName, { delay: 20 });
 
-      // Wait for search results to load
-      await loadingMessages.first().waitFor({ state: 'hidden', timeout: 60000 }).catch(() => {});
-      await workflowsPage.page.waitForLoadState('networkidle');
+      // Wait for search results to filter (indicated by "Top results" appearing)
+      await workflowsPage.page.getByText('Top results').waitFor({ state: 'visible', timeout: 30000 });
 
-      // Expand "Other (Custom, Foundry, etc.)" section if it exists
-      const otherSection = workflowsPage.page.getByText('Other (Custom, Foundry, etc.)');
+      // Expand "Other" section if it exists (label may vary across versions)
+      const otherSection = workflowsPage.page.getByText(/^Other \(/);
       if (await otherSection.isVisible({ timeout: 2000 }).catch(() => false)) {
         await otherSection.click();
 


### PR DESCRIPTION
The Falcon console changed how the workflow builder search input handles programmatic value setting around April 22, 2026. Playwright's `fill()` no longer triggers the search debounce, causing the action search to return no filtered results.

This switches to `pressSequentially()` which simulates real keyboard input and properly triggers the search filter. Also waits for "Top results" text as a reliable indicator that filtering completed (instead of `waitForLoadState`), and uses a regex for the "Other" section label which changed from "Other (Custom, Foundry, etc.)" to "Other (AgentWorks, Foundry, HTTP actions, etc.)".

Verified locally: all 3 tests pass (41.1s).