### PR TITLE
Regenerate e2e package-lock.json for foundry-playwright 0.5.0

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@crowdstrike/foundry-playwright": "0.5.0",
-        "@types/node": "latest"
+        "@types/node": "25.6.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -130,13 +130,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
-      "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/commander": {
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Lock file was out of sync with package.json after the migration to @crowdstrike/foundry-playwright 0.5.0, causing `npm ci` to fail in CI. Regenerated to restore consistency.